### PR TITLE
Closes #9 - Create a "static website" playbook

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Damien Carcel
+Copyright (c) 2017 Damien Carcel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ My own ansible deployment scripts.
 - **`ttrss`: Install Tiny Tiny RSS**<br />
   This playbook allow the install and configuration of all Tiny Tiny RSS dependencies, but does not configure Tiny Tiny RSS itself.
   This is done at first launch, or by backup/restore scripts (which are not in this repository).
+- **`static-website`: Install a static HTML + JavaScript application**<br />
+  This playbook install a simple, static web site requiring only nginx to run.
+  The web site is installed into the remote user home folder, into a designated subfolder.
 
 ## Roles
 
@@ -15,8 +18,9 @@ My own ansible deployment scripts.
 - `php`: Install and configure PHP CLI (+ extensions), native 5.6 or 7.0 from added repository
 - `composer`: Install and configure composer
 - `fpm`: Install and configure PHP FPM (version 5.6 or 7.0)
-- `nginx`: Install and configure nginx according to PHP FPM settings
-- `ttrss`: Install and prepare Tiny Tiny RSS to use with nginx, PHP-FPM and MySQL
+- `nginx`: Install and configure nginx
+- `ttrss`: Install and prepare Tiny Tiny RSS (to use with nginx, PHP-FPM and MySQL)
+- `static-website`: Install and configure a simple static website from its git repository (to use with nginx)
 
 # License
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,5 @@
 [defaults]
 nocows = 1
+
+[ssh_connection]
+ssh_args = -o ForwardAgent=yes

--- a/inventories/static-website.dist
+++ b/inventories/static-website.dist
@@ -1,0 +1,13 @@
+[static-website]
+server_host_name_or_ip
+
+[static-website:vars]
+host_remote_user=
+static_website_url=
+static_website_git_repo=
+static_website_git_version=
+static_website_destination_path=
+static_website_server_path=
+static_website_htpassword_protected=
+static_website_htlogin=
+static_website_htpassword=

--- a/roles/composer/tasks/composer-config.yml
+++ b/roles/composer/tasks/composer-config.yml
@@ -1,0 +1,8 @@
+---
+- name: Prepare composer directory
+  file: path=/home/{{ host_remote_user }}/.composer owner={{ host_remote_user }} state=directory
+  become: false
+
+- name: Set composer auth
+  template: src=composer_auth.json.j2 dest=/home/{{ host_remote_user }}/.composer/auth.json owner={{ host_remote_user }}
+  become: false

--- a/roles/composer/tasks/composer-install.yml
+++ b/roles/composer/tasks/composer-install.yml
@@ -1,0 +1,3 @@
+---
+- name: Install composer
+  script: roles/composer/scripts/install.sh

--- a/roles/composer/tasks/main.yml
+++ b/roles/composer/tasks/main.yml
@@ -1,11 +1,6 @@
 ---
-- name: Install composer
-  script: roles/composer/scripts/install.sh
+- include: composer-install.yml
+  tags: ['composer-install']
 
-- name: Prepare composer directory
-  file: path=/home/{{ host_remote_user }}/.composer owner={{ host_remote_user }} state=directory
-  become: false
-
-- name: Set composer auth
-  template: src=composer_auth.json.j2 dest=/home/{{ host_remote_user }}/.composer/auth.json owner={{ host_remote_user }}
-  become: false
+- include: composer-config.yml
+  tags: ['composer-config']

--- a/roles/npm/tasks/main.yml
+++ b/roles/npm/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- include: npm-install.yml
+  tags: ['npm-install']
+
+- include: npm-packages.yml
+  tags: ['npm-packages']

--- a/roles/npm/tasks/npm-install.yml
+++ b/roles/npm/tasks/npm-install.yml
@@ -1,0 +1,20 @@
+---
+- name: Download NodeJS installation script
+  get_url:
+    url: https://deb.nodesource.com/setup_7.x
+    dest: /tmp/install_nodejs.sh
+    mode: 0777
+  become: false
+
+- name: Add NodeJS official repository
+  command: /tmp/install_nodejs.sh
+
+- name: Remove NodeJS installation script
+  file:
+    path: /tmp/install_nodejs.sh
+    state: absent
+  become: false
+
+- name: Install NodeJS and NPM packages
+  apt:
+    name: nodejs

--- a/roles/npm/tasks/npm-packages.yml
+++ b/roles/npm/tasks/npm-packages.yml
@@ -1,0 +1,5 @@
+---
+- name: Install "bower" globally
+  npm:
+    name: bower
+    global: yes

--- a/roles/static-website/handlers/main.yml
+++ b/roles/static-website/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Restart nginx
+  service: name=nginx state=restarted
+  become: true

--- a/roles/static-website/tasks/main.yml
+++ b/roles/static-website/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- include: static-website-install.yml
+  tags: ['static-website-install']
+
+- include: static-website-config.yml
+  tags: ['static-website-config']

--- a/roles/static-website/tasks/static-website-config.yml
+++ b/roles/static-website/tasks/static-website-config.yml
@@ -1,0 +1,6 @@
+---
+- name: Update bower packages
+  bower:
+    path: "{{ static_website_destination_path }}"
+    state: latest
+  become: false

--- a/roles/static-website/tasks/static-website-install.yml
+++ b/roles/static-website/tasks/static-website-install.yml
@@ -1,0 +1,41 @@
+---
+- name: Clone provided repository
+  git:
+    dest: "{{ static_website_destination_path }}"
+    repo: "{{ static_website_git_repo }}"
+    accept_hostkey: yes
+    force: yes
+    version: "{{ static_website_git_version }}"
+  become: false
+
+- name: Install some usefull packages
+  apt:
+    name: apache2-utils
+  when: static_website_htpassword_protected is defined and static_website_htpassword_protected|bool == true
+
+- name: Disable default server
+  file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+  notify: Restart nginx
+
+- name: Protect the website by htpassword
+  htpasswd:
+    path: "{{ static_website_destination_path }}/.htpassword"
+    name: "{{ static_website_htlogin }}"
+    password: "{{ static_website_htpassword }}"
+    owner: "{{ host_remote_user }}"
+    mode: 0640
+  when: static_website_htpassword_protected is defined and static_website_htpassword_protected|bool == true
+
+- name: Configure nginx server
+  template:
+    src: "{{ (static_website_htpassword_protected is defined and static_website_htpassword_protected|bool == true) | ternary('nginx_server_restricted.j2','nginx_server.j2') }}"
+    dest: "/etc/nginx/sites-available/{{ static_website_url }}"
+
+- name: Enable nginx server
+  file:
+    src: "/etc/nginx/sites-available/{{ static_website_url }}"
+    dest: "/etc/nginx/sites-enabled/{{ static_website_url }}"
+    state: link
+  notify: Restart nginx

--- a/roles/static-website/templates/nginx_server.j2
+++ b/roles/static-website/templates/nginx_server.j2
@@ -1,0 +1,18 @@
+server {
+    listen      80;
+    server_name {{ static_website_url }};
+    root        {{ static_website_server_path }};
+
+    location / {
+        index index.html index.htm index.php;
+    }
+
+    error_page 500 502 503 504  /50x.html;
+
+    location = /50x.html {
+        root {{ static_website_server_path }};
+    }
+
+    error_log /var/log/nginx/{{ static_website_url }}_error.log;
+    access_log /var/log/nginx/{{ static_website_url }}_access.log;
+}

--- a/roles/static-website/templates/nginx_server_restricted.j2
+++ b/roles/static-website/templates/nginx_server_restricted.j2
@@ -1,0 +1,20 @@
+server {
+    listen      80;
+    server_name {{ static_website_url }};
+    root        {{ static_website_server_path }};
+
+    location / {
+        index index.html index.htm index.php;
+        auth_basic "Restricted Content";
+        auth_basic_user_file {{ static_website_destination_path }}/.htpassword;
+    }
+
+    error_page 500 502 503 504  /50x.html;
+
+    location = /50x.html {
+        root {{ static_website_server_path }};
+    }
+
+    error_log /var/log/nginx/{{ static_website_url }}_error.log;
+    access_log /var/log/nginx/{{ static_website_url }}_access.log;
+}

--- a/roles/ttrss/tasks/ttrss-install.yml
+++ b/roles/ttrss/tasks/ttrss-install.yml
@@ -8,7 +8,6 @@
 
 - name: Configure nginx server
   template: src=nginx_server.j2 dest=/etc/nginx/sites-available/ttrss
-  notify: Restart nginx
 
 - name: Enable nginx server
   file: src=/etc/nginx/sites-available/ttrss dest=/etc/nginx/sites-enabled/ttrss state=link

--- a/static-website.yml
+++ b/static-website.yml
@@ -1,0 +1,27 @@
+---
+- name: Ansible prerequisites
+  hosts: static-website
+  gather_facts: False
+  remote_user: "{{ host_remote_user }}"
+  become: true
+  tags: ['prerequisites']
+  tasks:
+    - name: Check if apt repo needs to be updated
+      raw: ls -1 /var/cache/apt/pkgcache.bin || true
+      register: apt_repo_cache
+
+    - name: Update repos
+      raw: apt-get update
+      when: apt_repo_cache.stdout_lines[0] != "/var/cache/apt/pkgcache.bin"
+
+    - name: Make sure python and deps are installed
+      raw: apt-get -y install python python-apt apt-utils python-requests python-passlib
+
+- name: Static website install
+  hosts: static-website
+  remote_user: "{{ host_remote_user }}"
+  roles:
+    - { role: debian-jessie, become: true, tags: ['debian-jessie'] }
+    - { role: nginx, become: true, tags: ['nginx'] }
+    - { role: npm, become: true, tags: ['npm'] }
+    - { role: static-website, become: true, tags: ['static-website'] }


### PR DESCRIPTION
Relates to #9.

This PR adds a playbook to deploy easily a simple static website.
- [x] it clones a GIT repository
- [x] it set up a corresponding nginx server 
- [x] it install bower package manager and use it to update the website assets
- [x] optionally, it add a protection by http login 