### PR TITLE
Closes #18 - Remove bower from "npm" role

### DIFF
--- a/inventories/static-website.dist
+++ b/inventories/static-website.dist
@@ -11,3 +11,4 @@ static_website_server_path=
 static_website_htpassword_protected=
 static_website_htlogin=
 static_website_htpassword=
+static_website_build_command=

--- a/roles/npm/tasks/main.yml
+++ b/roles/npm/tasks/main.yml
@@ -8,8 +8,3 @@
 - name: Install NodeJS and NPM packages
   apt:
     name: nodejs
-
-- name: Install "bower" globally
-  npm:
-    name: bower
-    global: yes

--- a/roles/static-website/tasks/main.yml
+++ b/roles/static-website/tasks/main.yml
@@ -9,7 +9,7 @@
   become: false
   notify: Restart nginx
 
-- name: Install some usefull packages
+- name: Install utility programs for webservers
   apt:
     name: apache2-utils
   when: static_website_htpassword_protected is defined and static_website_htpassword_protected|bool == true
@@ -48,8 +48,14 @@
     state: link
   notify: Restart nginx
 
-- name: Update bower packages
-  bower:
-    path: "{{ static_website_destination_path }}"
-    state: latest
+- name: Install application dependencies
+  command: npm install
+  args:
+    chdir: "{{ static_website_destination_path }}"
+  become: false
+
+- name: Build application
+  command: npm run {{ static_website_build_command }}
+  args:
+    chdir: "{{ static_website_destination_path }}"
   become: false


### PR DESCRIPTION
Relates to #18.

Make "static-website" role more generic.
For example, `bower` must be installed as a local dependency through `npm`, and run thanks to a npm script `npm run bower`.