### PR TITLE
Closes #22 - Use Yarn to install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,16 @@ One must ensure the following packages are installed on the remote machine, or A
 
 ## Roles
 
-- `debian-jessie`: define repositories, set system up to date, add some useful packages and remove useless ones
-- `mysql`: Install and configure native MySQL 5.5
-- `php`: Install and configure PHP CLI (+ extensions), native 5.6 or 7.0 from added repository
-- `composer`: Install and configure composer
-- `fpm`: Install and configure PHP FPM (version 5.6 or 7.0)
+- `debian`: Define repositories, set system up to date, add some useful packages and remove useless ones
+- `mysql`: Install and configure native MySQL 5.7
+- `php`: Install and configure PHP 7.1 from Ondřej Surý repository
+- `composer`: Install and configure Composer package manager
+- `fpm`: Install and configure PHP FPM (version 7.1)
 - `nginx`: Install and configure nginx
+- `npm`: Install and configure NodeJS and NPM package manager
+- `yarn`: Install Yarn package manager
 - `ttrss`: Install and prepare Tiny Tiny RSS (to use with nginx, PHP-FPM and MySQL)
-- `static-website`: Install and configure a simple static website from its git repository (to use with nginx)
+- `static-website`: Install and configure an HTML5 website from its git repository (to use with nginx)
 
 # License
 

--- a/roles/static-website/tasks/main.yml
+++ b/roles/static-website/tasks/main.yml
@@ -36,14 +36,14 @@
   when: static_website_htpassword_protected is defined and static_website_htpassword_protected|bool == true
   notify: Restart nginx
 
-- name: Install application dependencies
-  command: npm install
+- name: Install application dependencies with Yarn
+  command: yarn install
   args:
     chdir: "{{ static_website_destination_path }}"
   when: static_website_build_command is defined and (static_website_dependencies_prod_only is undefined or static_website_dependencies_prod_only|bool == false)
   become: false
 
-- name: Install application production only dependencies
+- name: Install application production only dependencies with NPM
   command: npm install --only=prod
   args:
     chdir: "{{ static_website_destination_path }}"

--- a/roles/yarn/tasks/main.yml
+++ b/roles/yarn/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Add Yarn repository key
+  apt_key: url=https://dl.yarnpkg.com/debian/pubkey.gpg state=present
+
+- name: Add Yarn official repository
+  apt_repository: repo="deb https://dl.yarnpkg.com/debian/ stable main" state=present
+
+- name: Install Yarn
+  apt:
+    name: yarn

--- a/static-website.yml
+++ b/static-website.yml
@@ -6,4 +6,5 @@
     - { role: debian, become: true, tags: ['debian'] }
     - { role: nginx, become: true, tags: ['nginx'] }
     - { role: npm, become: true, tags: ['npm'] }
+    - { role: yarn, become: true, tags: ['yarn'] }
     - { role: static-website, become: true, tags: ['static-website'] }


### PR DESCRIPTION
Relates to #22

Create a Yarn role and use it in static-website playbook