### PR TITLE
Issue 27: Use http/2 protocol

### DIFF
--- a/roles/composer/tasks/main.yml
+++ b/roles/composer/tasks/main.yml
@@ -3,9 +3,15 @@
   script: roles/composer/scripts/install.sh
 
 - name: Prepare composer directory
-  file: path=/home/{{ host_remote_user }}/.composer owner={{ host_remote_user }} state=directory
+  file:
+    path: "/home/{{ host_remote_user }}/.composer"
+    owner: "{{ host_remote_user }}"
+    state: directory
   become: false
 
 - name: Set composer auth
-  template: src=composer_auth.json.j2 dest=/home/{{ host_remote_user }}/.composer/auth.json owner={{ host_remote_user }}
+  template:
+    src: composer_auth.json.j2
+    dest: "/home/{{ host_remote_user }}/.composer/auth.json"
+    owner: "{{ host_remote_user }}"
   become: false

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -1,40 +1,55 @@
 ---
 - name: Set Debian repository
-  copy: src="debian_sources.list" dest="/etc/apt/sources.list" mode=0644 owner=root
+  copy:
+    src: debian_sources.list
+    dest: /etc/apt/sources.list
+    mode: 0644
+    owner: root
 
 - name: Install some usefull packages
-  apt: name={{ item }} update_cache=yes
-  with_items:
-    - apt-transport-https
-    - bzip2
-    - ca-certificates
-    - cron
-    - curl
-    - git
-    - iputils-ping
-    - less
-    - logrotate
-    - man-db
-    - reboot-notifier
-    - rsync
-    - vim
-    - wget
+  apt:
+    name: "{{ packages }}"
+    update_cache: yes
+  vars:
+    packages:
+      - apt-transport-https
+      - bzip2
+      - ca-certificates
+      - cron
+      - curl
+      - git
+      - iputils-ping
+      - less
+      - logrotate
+      - man-db
+      - reboot-notifier
+      - rsync
+      - vim
+      - wget
 
 - name: Remove useless packages
-  apt: name={{ item }} purge=yes state=absent
-  with_items:
-    - at
-    - nano
-    - tasksel
-    - tasksel-data
-    - vim-tiny
+  apt:
+    name: "{{ packages }}"
+    purge: yes
+    state: absent
+  vars:
+    packages:
+      - at
+      - nano
+      - tasksel
+      - tasksel-data
+      - vim-tiny
 
 - name: Upgrade all packages to the latest version
-  apt: update_cache=yes upgrade=dist
+  apt:
+    update_cache: yes
+    upgrade: dist
 
 - name: Check if a reboot is required
   register: file
-  stat: path=/var/run/reboot-required get_md5=no
+  stat:
+    path: /var/run/reboot-required
+    get_md5: no
 
 - name: Reboot the server
   shell: sleep 2 && /sbin/reboot

--- a/roles/fpm/handlers/main.yml
+++ b/roles/fpm/handlers/main.yml
@@ -1,4 +1,6 @@
 ---
 - name: Restart FPM
-  service: name=php7.1-fpm state=restarted
+  service:
+    name: php7.1-fpm
+    state: restarted
   become: true

--- a/roles/fpm/tasks/main.yml
+++ b/roles/fpm/tasks/main.yml
@@ -1,21 +1,27 @@
 ---
 - name: Install PHP FPM package
-  apt: name={{ item }}
-  with_items:
-    - php7.1-fpm
+  apt:
+    name: php7.1-fpm
 
 - name: Enable PHP FPM
-  service: name=php7.1-fpm enabled=yes
+  service:
+    name: php7.1-fpm
+    enabled: yes
 
 - name: Setting up PHP FPM config
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini regexp="{{ item.regexp }}" line="{{ item.line }}"
+  lineinfile:
+    dest: /etc/php/7.1/fpm/php.ini
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
   with_items:
     - { regexp: '^memory_limit', line: 'memory_limit = 512M' }
     - { regexp: '^;?date\.timezone =', line: 'date.timezone = Europe/Paris' }
 
-
 - name: Setting up PHP FPM web config
-  lineinfile: dest=/etc/php/7.1/fpm/pool.d/www.conf regexp="{{ item.regexp }}" line="{{ item.line }}"
+  lineinfile:
+    dest: /etc/php/7.1/fpm/pool.d/www.conf
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
   with_items:
     - { regexp: '^user =', line: 'user = {{ host_remote_user }}' }
     - { regexp: '^group =', line: 'group = {{ host_remote_user }}' }

--- a/roles/https/tasks/main.yml
+++ b/roles/https/tasks/main.yml
@@ -10,11 +10,11 @@
     default_release: stretch-backports
 
 - name: Configure Let's Encrypt for nginx server
-  command: certbot -n --nginx -d {{ website_url }} --agree-tos --redirect -m damien.carcel@gmail.com
+  command: "certbot -n --nginx -d {{ website_url }} --agree-tos --redirect -m damien.carcel@gmail.com"
 
 - name: Active http/2
   replace:
-    path: /etc/nginx/sites-available/{{ website_url }}
+    path: "/etc/nginx/sites-available/{{ website_url }}"
     regexp: 'listen 443 ssl'
     replace: 'listen 443 ssl http2'
     backup: yes

--- a/roles/https/tasks/main.yml
+++ b/roles/https/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add Debian Stretch "backport" repository
   apt_repository:
-    repo: "deb http://ftp.fr.debian.org/debian stretch-backports main"
+    repo: deb http://ftp.fr.debian.org/debian stretch-backports main
     state: present
 
 - name: Install Certbot from "squeeze-backport"

--- a/roles/https/tasks/main.yml
+++ b/roles/https/tasks/main.yml
@@ -11,3 +11,10 @@
 
 - name: Configure Let's Encrypt for nginx server
   command: certbot -n --nginx -d {{ website_url }} --agree-tos --redirect -m damien.carcel@gmail.com
+
+- name: Active http/2
+  replace:
+    path: /etc/nginx/sites-available/{{ website_url }}
+    regexp: 'listen 443 ssl'
+    replace: 'listen 443 ssl http2'
+    backup: yes

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -1,12 +1,16 @@
 ---
 - name: Install MySQL package
-  apt: name="{{ item }}"
-  with_items:
-    - python-mysqldb
-    - mysql-server
+  apt:
+    name: "{{ packages }}"
+  vars:
+    packages:
+      - python-mysqldb
+      - mysql-server
 
 - name: Enable MySQL server
-  service: name=mysql enabled=yes
+  service:
+    name: mysql
+    enabled: yes
 
 - name: Update MySQL root password for all root accounts
   mysql_user:

--- a/roles/nginx/handlers/main.yml
+++ b/roles/nginx/handlers/main.yml
@@ -1,4 +1,6 @@
 ---
 - name: Restart nginx
-  service: name=nginx state=restarted
+  service:
+    name: nginx
+    state: restarted
   become: true

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,10 +1,16 @@
 ---
 - name: Install nginx
-  apt: name=nginx
+  apt:
+    name: nginx
 
 - name: Enable nginx
-  service: name=nginx enabled=yes
+  service:
+    name: nginx
+    enabled: yes
 
 - name: Configure nginx user
-  lineinfile: dest=/etc/nginx/nginx.conf regexp="^user" line="user {{ host_remote_user }};"
+  lineinfile:
+    dest: /etc/nginx/nginx.conf
+    regexp: "^user"
+    line: "user {{ host_remote_user }};"
   notify: Restart nginx

--- a/roles/npm/tasks/main.yml
+++ b/roles/npm/tasks/main.yml
@@ -1,9 +1,13 @@
 ---
 - name: Add NodeJS repository key
-  apt_key: url=https://deb.nodesource.com/gpgkey/nodesource.gpg.key state=present
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    state: present
 
 - name: Add NodeJS official repository
-  apt_repository: repo="deb https://deb.nodesource.com/node_8.x stretch main" state=present
+  apt_repository:
+    repo: deb https://deb.nodesource.com/node_8.x stretch main
+    state: present
 
 - name: Install NodeJS and NPM
   apt:

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -1,31 +1,42 @@
 ---
 - name: Add PHP repository key
-  apt_key: url=https://packages.sury.org/php/apt.gpg state=present
+  apt_key:
+    url: https://packages.sury.org/php/apt.gpg
+    state: present
 
 - name: Add PHP repository
-  apt_repository: repo="deb https://packages.sury.org/php/ stretch main" state=present
+  apt_repository:
+    repo: deb https://packages.sury.org/php/ stretch main
+    state: present
 
 - name: Install PHP packages
-  apt: name={{ item }}
-  with_items:
-    - php7.1-apcu
-    - php7.1-cli
-    - php7.1-bcmath
-    - php7.1-curl
-    - php7.1-gd
-    - php7.1-intl
-    - php7.1-mbstring
-    - php7.1-mcrypt
-    - php7.1-mysql
-    - php7.1-soap
-    - php7.1-xml
-    - php7.1-zip
+  apt:
+    name: "{{ packages }}"
+  vars:
+    packages:
+      - php7.1-apcu
+      - php7.1-cli
+      - php7.1-bcmath
+      - php7.1-curl
+      - php7.1-gd
+      - php7.1-intl
+      - php7.1-mbstring
+      - php7.1-mcrypt
+      - php7.1-mysql
+      - php7.1-soap
+      - php7.1-xml
+      - php7.1-zip
 
 - name: Set default PHP
-  alternatives: name=php path=/usr/bin/php7.1
+  alternatives:
+    name: php
+    path: /usr/bin/php7.1
 
 - name: Setting up PHP CLI config
-  lineinfile: dest=/etc/php/7.1/cli/php.ini regexp="{{ item.regexp }}" line="{{ item.line }}"
+  lineinfile:
+    dest: /etc/php/7.1/cli/php.ini
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
   with_items:
     - { regexp: '^memory_limit', line: 'memory_limit = 1G' }
     - { regexp: '^;?date\.timezone =', line: 'date.timezone = Europe/Paris' }

--- a/roles/static-website/handlers/main.yml
+++ b/roles/static-website/handlers/main.yml
@@ -1,4 +1,6 @@
 ---
 - name: Restart nginx
-  service: name=nginx state=restarted
+  service:
+    name: nginx
+    state: restarted
   become: true

--- a/roles/static-website/tasks/main.yml
+++ b/roles/static-website/tasks/main.yml
@@ -51,7 +51,7 @@
   become: false
 
 - name: Build application
-  command: npm run {{ static_website_build_command }}
+  command: "npm run {{ static_website_build_command }}"
   args:
     chdir: "{{ static_website_destination_path }}"
   when: static_website_build_command is defined and static_website_build_command != 'none'

--- a/roles/static-website/templates/nginx_server.j2
+++ b/roles/static-website/templates/nginx_server.j2
@@ -1,5 +1,4 @@
 server {
-    listen      80;
     server_name {{ website_url }};
     root        {{ static_website_server_path }};
 

--- a/roles/static-website/templates/nginx_server_restricted.j2
+++ b/roles/static-website/templates/nginx_server_restricted.j2
@@ -1,5 +1,4 @@
 server {
-    listen      80;
     server_name {{ website_url }};
     root        {{ static_website_server_path }};
 

--- a/roles/ttrss/handlers/main.yml
+++ b/roles/ttrss/handlers/main.yml
@@ -1,8 +1,12 @@
 ---
 - name: Restart nginx
-  service: name=nginx state=restarted
+  service:
+    name: nginx
+    state: restarted
   become: true
 
 - name: Restart ttrss daemon
-  service: name=ttrss state=restarted
+  service:
+    name: ttrss
+    state: restarted
   become: true

--- a/roles/ttrss/tasks/ttrss-config.yml
+++ b/roles/ttrss/tasks/ttrss-config.yml
@@ -3,19 +3,21 @@
   meta: flush_handlers
 
 - name: Create TTRSS database if none
-  mysql_db: name={{ mysql_ttrss_database }}
-            login_user=root
-            login_password={{ mysql_root_password }}
-            state=present
+  mysql_db:
+    name: "{{ mysql_ttrss_database }}"
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+    state: present
   register: create_mysql_database
 
 - name: Configure user and password for TTRSS table
-  mysql_user: name={{ mysql_ttrss_user }}
-              password={{ mysql_ttrss_password }}
-              priv={{ mysql_ttrss_database }}.*:ALL,GRANT
-              login_user=root
-              login_password={{ mysql_root_password }}
-              state=present
+  mysql_user:
+    name: "{{ mysql_ttrss_user }}"
+    password: "{{ mysql_ttrss_password }}"
+    priv: "{{ mysql_ttrss_database }}.*:ALL,GRANT"
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+    state: present
   register: create_mysql_user
 
 - name: Wait for TTRSS to be configured
@@ -24,8 +26,12 @@
   when: create_mysql_database is changed or create_mysql_user is changed
 
 - name: Create feeds update service
-  template: src=ttrss.service.j2 dest=/etc/systemd/system/ttrss.service
+  template:
+    src: ttrss.service.j2
+    dest: /etc/systemd/system/ttrss.service
   notify: Restart ttrss daemon
 
 - name: Enable feeds update service
-  service: name=ttrss enabled=yes
+  service:
+    name: ttrss
+    enabled: yes

--- a/roles/ttrss/tasks/ttrss-config.yml
+++ b/roles/ttrss/tasks/ttrss-config.yml
@@ -19,8 +19,9 @@
   register: create_mysql_user
 
 - name: Wait for TTRSS to be configured
-  wait_for: path=/home/{{ host_remote_user }}/ttrss/config.php
-  when: create_mysql_database|changed or create_mysql_user|changed
+  wait_for:
+    path: "/home/{{ host_remote_user }}/ttrss/config.php"
+  when: create_mysql_database is changed or create_mysql_user is changed
 
 - name: Create feeds update service
   template: src=ttrss.service.j2 dest=/etc/systemd/system/ttrss.service

--- a/roles/ttrss/tasks/ttrss-install.yml
+++ b/roles/ttrss/tasks/ttrss-install.yml
@@ -1,9 +1,10 @@
 ---
 - name: Clone Tiny Tiny RSS repository
-  git: dest=/home/{{ host_remote_user }}/ttrss
-       repo=https://tt-rss.org/git/tt-rss.git
-       accept_hostkey=yes
-       force=yes
+  git:
+    dest: /home/{{ host_remote_user }}/ttrss
+    repo: https://tt-rss.org/git/tt-rss.git
+    accept_hostkey: yes
+    force: yes
   become: false
 
 - name: Disable default server
@@ -13,8 +14,13 @@
   notify: Restart nginx
 
 - name: Configure nginx server
-  template: src=nginx_server.j2 dest=/etc/nginx/sites-available/{{ website_url }}
+  template:
+    src: nginx_server.j2
+    dest: /etc/nginx/sites-available/{{ website_url }}
 
 - name: Enable nginx server
-  file: src=/etc/nginx/sites-available/{{ website_url }} dest=/etc/nginx/sites-enabled/{{ website_url }} state=link
+  file:
+    src: /etc/nginx/sites-available/{{ website_url }}
+    dest: /etc/nginx/sites-enabled/{{ website_url }}
+    state: link
   notify: Restart nginx

--- a/roles/ttrss/templates/nginx_server.j2
+++ b/roles/ttrss/templates/nginx_server.j2
@@ -1,5 +1,4 @@
 server {
-    listen      80;
     server_name {{ website_url }};
     root        /home/{{ host_remote_user }}/ttrss;
 

--- a/roles/yarn/tasks/main.yml
+++ b/roles/yarn/tasks/main.yml
@@ -1,9 +1,13 @@
 ---
 - name: Add Yarn repository key
-  apt_key: url=https://dl.yarnpkg.com/debian/pubkey.gpg state=present
+  apt_key:
+    url: https://dl.yarnpkg.com/debian/pubkey.gpg
+    state: present
 
 - name: Add Yarn official repository
-  apt_repository: repo="deb https://dl.yarnpkg.com/debian/ stable main" state=present
+  apt_repository:
+    repo: deb https://dl.yarnpkg.com/debian/ stable main
+    state: present
 
 - name: Install Yarn
   apt:


### PR DESCRIPTION
This PR relates to #27.
- It configures all `nginx` servers to use http/2
- It fixes all current deprecation warnings
- It makes use of YAML associative arrays everywhere possible, replacing
    ```yaml
    - name: foo
      file: path=bar
    ```
    by
    ```yaml
    - name: foo
      file:
        path: bar
    ```