### PR TITLE
Issue 34: Ensure TTRSS feed daemon always run

### DIFF
--- a/roles/ttrss/handlers/main.yml
+++ b/roles/ttrss/handlers/main.yml
@@ -4,9 +4,3 @@
     name: nginx
     state: restarted
   become: true
-
-- name: Restart ttrss daemon
-  service:
-    name: ttrss
-    state: restarted
-  become: true

--- a/roles/ttrss/tasks/ttrss-config.yml
+++ b/roles/ttrss/tasks/ttrss-config.yml
@@ -36,9 +36,9 @@
   template:
     src: ttrss.service.j2
     dest: /etc/systemd/system/ttrss.service
-  notify: Restart ttrss daemon
 
-- name: Enable feeds update service
+- name: Enable and start feeds update service
   service:
     name: ttrss
     enabled: yes
+    state: restarted


### PR DESCRIPTION
Do not use a handler to restart the daemon, just always restart it after an update.